### PR TITLE
Check if query is null

### DIFF
--- a/lib/mongo_service.dart
+++ b/lib/mongo_service.dart
@@ -54,7 +54,7 @@ class MongoService extends Service<String, Map<String, dynamic>> {
       } else if (key == 'query' &&
           (allowQuery == true || !params.containsKey('provider'))) {
         var query = params[key] as Map;
-        query.forEach((key, v) {
+        query?.forEach((key, v) {
           var value = v is Map<String, dynamic> ? _filterNoQuery(v) : v;
 
           if (!_NO_QUERY.contains(key) &&


### PR DESCRIPTION
We have a problem with query execution on a graphql project.*

Our service is initialized here : 
var service = new MongoService(db.collection("todos"));

And we have a simple method to retrieve : 
return [
    field(
      'todos',
      listOf(todoGraphQLType),
      resolve: resolveViaServiceIndex(todoService),
    ),

To fix this issue, we add to modify MongoService to check if query is set.

